### PR TITLE
fix: avoid 'S&C' abbreviation in menu

### DIFF
--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -113,13 +113,13 @@
       full: Cross-Cutting WGs
 
 
-### Software and Computing (S&C)
+### Software and Computing
 #
 - name: sc
-  full: S&C
+  full: Software and Computing
   submenus:
     - name: sc_overview
-      full: Overview of Software and Computing
+      full: Overview
 
     - name: tutorials
       full: Tutorials


### PR DESCRIPTION
### Briefly, what does this PR introduce?
'S&C' is an abbreviation that doesn't mean anything to people who don't already know it. Use full name.