### PR TITLE
Update keywords.yml with new conferences

### DIFF
--- a/_data/keywords.yml
+++ b/_data/keywords.yml
@@ -249,6 +249,27 @@
 
 # 2024
 
+- name: laubach2024
+  description: Workshop on the structure and spectroscopy of hadrons with relation to the EIC and JLab22
+  category: conference
+  upload: no
+  year: 2024
+  url: ''
+
+- name: him2024
+  description: 2024 3rd Heavy-ion meeting (HIM): Researches on the future accelerators and colliders
+  category: conference
+  upload: no
+  year: 2024
+  url: 'https://www.apctp.org/theme/d/html/activities/activities01_read.php?id=2179&page=1'
+
+- name: cpad2024
+  description: Coordinating Panel for Advanced Detectors Workshop
+  category: conference
+  upload: no
+  year: 2024
+  url: 'https://indico.phy.ornl.gov/event/510/'
+
 - name: aum2024
   description: The RHIC/AGS Users Meeting (2024)
   category:  conference


### PR DESCRIPTION
Added keyword entries for Laubach, HIM, and CPAD workshops. Laubach workshop does not have a website, so URL tag is left blank. Not sure how the website code will parse this.

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
