### PR TITLE
Moved S&C to the front (public) page

### DIFF
--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -122,50 +122,6 @@
       full: Cross-Cutting WGs
 
 
-### Software and Computing
-#
-- name: sc
-  full: Software and Computing
-  submenus:
-    - name: sc_overview
-      full: Overview
-
-    - name: tutorials
-      full: Tutorials
-
-    - name: projects
-      full: Projects
-
-    - name: wg
-      label: yes
-      full: ' Working Groups'
-
-    - name: production
-      full: Production
-
-    - name: learning
-      full: User Learning
-
-    - name: validation
-      full: Validation
-
-    - name: simulation
-      full: Simulation
-
-    - name: reconstruction
-      full: Reconstruction
-
-    - name: streaming
-      full: Streaming Computing
-
-    # - name: separator
-    #   label: yes
-    #   full: ' '
-
-    # - name: resources
-    #   full: Resources
-
-
 #       div: yes
 
 ### MEETINGS

--- a/_data/menus_public.yml
+++ b/_data/menus_public.yml
@@ -13,7 +13,6 @@
 - name: public
   full: Public
   submenus:
-
     - name: overview
       full: Overview
 
@@ -26,8 +25,52 @@
     - name: press
       full: Media/Press
 
+
 ### INTERNAL
 - name: internal
-  full: For Collaborators
+  full: For Collaborators (Internal)
   link: "/index-internal.html"
 
+
+### Software and Computing
+#
+- name: sc
+  full: Software and Computing
+  submenus:
+    - name: sc_overview
+      full: Overview
+
+    - name: tutorials
+      full: Tutorials
+
+    - name: projects
+      full: Projects
+
+    - name: wg
+      label: yes
+      full: ' Working Groups'
+
+    - name: production
+      full: Production
+
+    - name: learning
+      full: User Learning
+
+    - name: validation
+      full: Validation
+
+    - name: simulation
+      full: Simulation
+
+    - name: reconstruction
+      full: Reconstruction
+
+    - name: streaming
+      full: Streaming Computing
+
+    # - name: separator
+    #   label: yes
+    #   full: ' '
+
+    # - name: resources
+    #   full: Resources

--- a/_layouts/home_public.html
+++ b/_layouts/home_public.html
@@ -12,7 +12,7 @@ layout: public
 	
         <div class="col-md-5">
           <p class="lead">
-	    <h4>WORK IN PROGRESS! This is the home of the future public website of the ePIC Collaboration.</h4>
+	    <h4>WORK IN PROGRESS! This is the public website of the ePIC Collaboration.</h4>
 	    Pardon the dust.
 	  <hr/>
 	  </p>


### PR DESCRIPTION
As per Markus' request, move the software and computing section to the public area of the website.
